### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/mcpctl.py
+++ b/mcpctl.py
@@ -149,13 +149,16 @@ def find_server_processes() -> List[Dict]:
                             server_name = Path(arg).stem
                             if server_name in server_names:
                                 # Find the key in SERVERS
-                                server_key = server_name.replace("_server", "").replace("_", "-")
+                                server_key = server_name.replace("_server", "").replace(
+                                    "_", "-"
+                                )
                                 server_processes.append(
                                     {
                                         "key": server_key,
                                         "name": SERVERS[server_key]["name"],
                                         "pid": proc.info["pid"],
-                                        "uptime": time.time() - proc.info["create_time"],
+                                        "uptime": time.time()
+                                        - proc.info["create_time"],
                                         "process": proc,
                                     }
                                 )
@@ -195,7 +198,9 @@ def cli(ctx, version):
 
 
 @cli.command()
-@click.option("--check-only", is_flag=True, help="Only check configuration without starting")
+@click.option(
+    "--check-only", is_flag=True, help="Only check configuration without starting"
+)
 def start(check_only):
     """Start all MCP servers (validates configuration)"""
     print_header("MCP Server Configuration Check")
@@ -315,7 +320,9 @@ def stop():
     # Graceful shutdown
     for server in server_processes:
         try:
-            click.echo(f"  → Sending SIGTERM to {server['name']} (PID: {server['pid']})")
+            click.echo(
+                f"  → Sending SIGTERM to {server['name']} (PID: {server['pid']})"
+            )
             server["process"].terminate()
         except psutil.NoSuchProcess:
             print_success(f"Process {server['name']} already terminated")
@@ -336,7 +343,9 @@ def stop():
             pass
 
     if still_running:
-        print_warning(f"{len(still_running)} process(es) still running, forcing termination...")
+        print_warning(
+            f"{len(still_running)} process(es) still running, forcing termination..."
+        )
         for server in still_running:
             try:
                 click.echo(f"  → Force killing {server['name']} (PID: {server['pid']})")
@@ -377,7 +386,9 @@ def status(verbose):
                     click.echo(f"    Env vars: {', '.join(server['env_vars'])}")
                 click.echo()
     else:
-        click.echo(f"{Colors.GREEN}{len(server_processes)} server(s) running:{Colors.RESET}\n")
+        click.echo(
+            f"{Colors.GREEN}{len(server_processes)} server(s) running:{Colors.RESET}\n"
+        )
 
         for server in server_processes:
             uptime_mins = int(server["uptime"] / 60)
@@ -503,7 +514,9 @@ def logs(server, lines, follow, all):
 
 @cli.command()
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed test output")
-@click.option("--timeout", "-t", default=3, help="Timeout for each server test (seconds)")
+@click.option(
+    "--timeout", "-t", default=3, help="Timeout for each server test (seconds)"
+)
 def test(verbose, timeout):
     """Run quick integration checks on all servers"""
     print_header("MCP Server Integration Tests")
@@ -575,7 +588,9 @@ def dashboard():
     is_flag=True,
     help="Start only the dashboard without starting servers",
 )
-@click.option("--servers-only", is_flag=True, help="Start only the servers without the dashboard")
+@click.option(
+    "--servers-only", is_flag=True, help="Start only the servers without the dashboard"
+)
 def run(dashboard_only, servers_only):
     """Start all MCP servers and dashboard with a single command"""
     print_header("Starting MCP Environment")
@@ -746,7 +761,9 @@ def config():
             for var in server["env_vars"]:
                 is_set = bool(os.getenv(var))
                 status = (
-                    f"{Colors.GREEN}✓{Colors.RESET}" if is_set else f"{Colors.RED}✗{Colors.RESET}"
+                    f"{Colors.GREEN}✓{Colors.RESET}"
+                    if is_set
+                    else f"{Colors.RED}✗{Colors.RESET}"
                 )
                 value = "***" if is_set else "not set"
                 click.echo(f"    {status} {var}: {value}")

--- a/servers/base_client.py
+++ b/servers/base_client.py
@@ -111,7 +111,9 @@ class BaseClient:
 
             if "errors" in error_data and error_data["errors"]:
                 if isinstance(error_data["errors"], dict):
-                    errors = [f"{field}: {msg}" for field, msg in error_data["errors"].items()]
+                    errors = [
+                        f"{field}: {msg}" for field, msg in error_data["errors"].items()
+                    ]
                     return " | ".join(errors)
                 return str(error_data["errors"])
 
@@ -119,7 +121,9 @@ class BaseClient:
         except Exception:
             return response.text[:500]
 
-    def _make_request(self, method: str, endpoint: str, **kwargs: Any) -> requests.Response:
+    def _make_request(
+        self, method: str, endpoint: str, **kwargs: Any
+    ) -> requests.Response:
         """
         Make HTTP request with error handling.
 

--- a/servers/bash_server.py
+++ b/servers/bash_server.py
@@ -216,7 +216,9 @@ class BashExecutorClient:
             )
 
             try:
-                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(), timeout=timeout
+                )
             except asyncio.TimeoutError:
                 process.kill()
                 await process.wait()
@@ -260,7 +262,9 @@ class BashExecutorClient:
             if result["success"]:
                 self.logger.info(f"Command succeeded: {command}")
             else:
-                self.logger.warning(f"Command failed: {command} (exit code: {process.returncode})")
+                self.logger.warning(
+                    f"Command failed: {command} (exit code: {process.returncode})"
+                )
 
             return result
 
@@ -350,8 +354,12 @@ class BashExecutorClient:
             return {
                 "exists": dir_path.exists(),
                 "is_directory": dir_path.is_dir() if dir_path.exists() else False,
-                "readable": (os.access(dir_path, os.R_OK) if dir_path.exists() else False),
-                "writable": (os.access(dir_path, os.W_OK) if dir_path.exists() else False),
+                "readable": (
+                    os.access(dir_path, os.R_OK) if dir_path.exists() else False
+                ),
+                "writable": (
+                    os.access(dir_path, os.W_OK) if dir_path.exists() else False
+                ),
                 "path": str(dir_path),
                 "timestamp": datetime.now().isoformat(),
             }
@@ -402,7 +410,9 @@ class BashExecutorClient:
                             "type": "directory" if item.is_dir() else "file",
                             "path": str(item),
                             "size": stat_info.st_size,
-                            "modified": datetime.fromtimestamp(stat_info.st_mtime).isoformat(),
+                            "modified": datetime.fromtimestamp(
+                                stat_info.st_mtime
+                            ).isoformat(),
                         }
                     )
                 except (OSError, PermissionError):

--- a/servers/config.py
+++ b/servers/config.py
@@ -64,7 +64,11 @@ class BaseConfig:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert config to dictionary."""
-        return {key: value for key, value in self.__dict__.items() if not key.startswith("_")}
+        return {
+            key: value
+            for key, value in self.__dict__.items()
+            if not key.startswith("_")
+        }
 
 
 @dataclass
@@ -75,11 +79,15 @@ class FrappeConfig(BaseConfig):
     api_key: str = field(default_factory=lambda: os.getenv("FRAPPE_API_KEY", ""))
     api_secret: str = field(default_factory=lambda: os.getenv("FRAPPE_API_SECRET", ""))
     timeout: int = field(default_factory=lambda: int(os.getenv("FRAPPE_TIMEOUT", "30")))
-    max_retries: int = field(default_factory=lambda: int(os.getenv("FRAPPE_MAX_RETRIES", "3")))
+    max_retries: int = field(
+        default_factory=lambda: int(os.getenv("FRAPPE_MAX_RETRIES", "3"))
+    )
     pool_connections: int = field(
         default_factory=lambda: int(os.getenv("FRAPPE_POOL_CONNECTIONS", "5"))
     )
-    pool_maxsize: int = field(default_factory=lambda: int(os.getenv("FRAPPE_POOL_MAXSIZE", "10")))
+    pool_maxsize: int = field(
+        default_factory=lambda: int(os.getenv("FRAPPE_POOL_MAXSIZE", "10"))
+    )
 
     def __post_init__(self) -> None:
         self.site_url = self.site_url.rstrip("/")
@@ -94,8 +102,12 @@ class FrappeConfig(BaseConfig):
 class GoalAgentConfig(BaseConfig):
     """Goal agent configuration."""
 
-    max_workers: int = field(default_factory=lambda: int(os.getenv("GOAL_AGENT_MAX_WORKERS", "5")))
-    timeout: int = field(default_factory=lambda: int(os.getenv("GOAL_AGENT_TIMEOUT", "30")))
+    max_workers: int = field(
+        default_factory=lambda: int(os.getenv("GOAL_AGENT_MAX_WORKERS", "5"))
+    )
+    timeout: int = field(
+        default_factory=lambda: int(os.getenv("GOAL_AGENT_TIMEOUT", "30"))
+    )
     cache_enabled: bool = field(
         default_factory=lambda: os.getenv("CACHE_ENABLED", "true").lower() == "true"
     )
@@ -108,11 +120,17 @@ class GoalAgentConfig(BaseConfig):
 class GitHubConfig(BaseConfig):
     """GitHub server configuration."""
 
-    token: str = field(default_factory=lambda: os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN", ""))
+    token: str = field(
+        default_factory=lambda: os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN", "")
+    )
     timeout: int = field(default_factory=lambda: int(os.getenv("GITHUB_TIMEOUT", "30")))
-    max_retries: int = field(default_factory=lambda: int(os.getenv("GITHUB_MAX_RETRIES", "3")))
+    max_retries: int = field(
+        default_factory=lambda: int(os.getenv("GITHUB_MAX_RETRIES", "3"))
+    )
     # ADD THIS FIELD:
-    default_branch: str = field(default_factory=lambda: os.getenv("GITHUB_DEFAULT_BRANCH", "main"))
+    default_branch: str = field(
+        default_factory=lambda: os.getenv("GITHUB_DEFAULT_BRANCH", "main")
+    )
 
     def __post_init__(self) -> None:
         if self.token and not self.token.startswith(("ghp_", "github_pat_")):
@@ -133,7 +151,9 @@ class JiraConfig(BaseConfig):
     api_token: str = field(default_factory=lambda: os.getenv("JIRA_API_TOKEN", ""))
     project_key: str = field(default_factory=lambda: os.getenv("JIRA_PROJECT_KEY", ""))
     timeout: int = field(default_factory=lambda: int(os.getenv("JIRA_TIMEOUT", "30")))
-    max_retries: int = field(default_factory=lambda: int(os.getenv("JIRA_MAX_RETRIES", "3")))
+    max_retries: int = field(
+        default_factory=lambda: int(os.getenv("JIRA_MAX_RETRIES", "3"))
+    )
     rate_limit_delay: float = field(
         default_factory=lambda: float(os.getenv("JIRA_RATE_LIMIT_DELAY", "0.5"))
     )
@@ -156,9 +176,13 @@ class InternetConfig(BaseConfig):
     """Internet/search server configuration."""
 
     google_api_key: str = field(default_factory=lambda: os.getenv("GOOGLE_API_KEY", ""))
-    search_engine_id: str = field(default_factory=lambda: os.getenv("GOOGLE_SEARCH_ENGINE_ID", ""))
+    search_engine_id: str = field(
+        default_factory=lambda: os.getenv("GOOGLE_SEARCH_ENGINE_ID", "")
+    )
     timeout: int = field(default_factory=lambda: int(os.getenv("GOOGLE_TIMEOUT", "15")))
-    max_retries: int = field(default_factory=lambda: int(os.getenv("GOOGLE_MAX_RETRIES", "3")))
+    max_retries: int = field(
+        default_factory=lambda: int(os.getenv("GOOGLE_MAX_RETRIES", "3"))
+    )
 
     def get_required_fields(self) -> list[str]:
         return ["google_api_key", "search_engine_id"]
@@ -173,9 +197,12 @@ class RedisConfig(BaseConfig):
     db: int = field(default_factory=lambda: int(os.getenv("REDIS_DB", "0")))
     password: str | None = field(default_factory=lambda: os.getenv("REDIS_PASSWORD"))
     decode_responses: bool = field(
-        default_factory=lambda: os.getenv("REDIS_DECODE_RESPONSES", "true").lower() == "true"
+        default_factory=lambda: os.getenv("REDIS_DECODE_RESPONSES", "true").lower()
+        == "true"
     )
-    socket_timeout: int = field(default_factory=lambda: int(os.getenv("REDIS_SOCKET_TIMEOUT", "5")))
+    socket_timeout: int = field(
+        default_factory=lambda: int(os.getenv("REDIS_SOCKET_TIMEOUT", "5"))
+    )
     socket_connect_timeout: int = field(
         default_factory=lambda: int(os.getenv("REDIS_SOCKET_CONNECT_TIMEOUT", "5"))
     )
@@ -183,7 +210,8 @@ class RedisConfig(BaseConfig):
         default_factory=lambda: int(os.getenv("REDIS_MAX_CONNECTIONS", "50"))
     )
     retry_on_timeout: bool = field(
-        default_factory=lambda: os.getenv("REDIS_RETRY_ON_TIMEOUT", "true").lower() == "true"
+        default_factory=lambda: os.getenv("REDIS_RETRY_ON_TIMEOUT", "true").lower()
+        == "true"
     )
     health_check_interval: int = field(
         default_factory=lambda: int(os.getenv("REDIS_HEALTH_CHECK_INTERVAL", "30"))
@@ -202,9 +230,15 @@ class PostgresConfig(BaseConfig):
     database: str = field(default_factory=lambda: os.getenv("POSTGRES_DB", "mcp_goals"))
     user: str = field(default_factory=lambda: os.getenv("POSTGRES_USER", "postgres"))
     password: str = field(default_factory=lambda: os.getenv("POSTGRES_PASSWORD", ""))
-    pool_size: int = field(default_factory=lambda: int(os.getenv("POSTGRES_POOL_SIZE", "10")))
-    max_overflow: int = field(default_factory=lambda: int(os.getenv("POSTGRES_MAX_OVERFLOW", "20")))
-    ssl_mode: str = field(default_factory=lambda: os.getenv("POSTGRES_SSL_MODE", "prefer"))
+    pool_size: int = field(
+        default_factory=lambda: int(os.getenv("POSTGRES_POOL_SIZE", "10"))
+    )
+    max_overflow: int = field(
+        default_factory=lambda: int(os.getenv("POSTGRES_MAX_OVERFLOW", "20"))
+    )
+    ssl_mode: str = field(
+        default_factory=lambda: os.getenv("POSTGRES_SSL_MODE", "prefer")
+    )
 
     def get_connection_string(self) -> str:
         """Get PostgreSQL connection string."""
@@ -219,8 +253,12 @@ class PostgresConfig(BaseConfig):
 class CacheServerConfig(BaseConfig):
     """Cache server configuration for goal agent."""
 
-    url: str = field(default_factory=lambda: os.getenv("CACHE_SERVER_URL", "http://localhost:8001"))
-    timeout: int = field(default_factory=lambda: int(os.getenv("CACHE_SERVER_TIMEOUT", "5")))
+    url: str = field(
+        default_factory=lambda: os.getenv("CACHE_SERVER_URL", "http://localhost:8001")
+    )
+    timeout: int = field(
+        default_factory=lambda: int(os.getenv("CACHE_SERVER_TIMEOUT", "5"))
+    )
     enabled: bool = field(
         default_factory=lambda: os.getenv("CACHE_ENABLED", "true").lower() == "true"
     )
@@ -254,7 +292,9 @@ def validate_config(config: BaseConfig, logger: Any = None) -> None:
     is_valid, errors = config.validate()
 
     if not is_valid:
-        error_msg = "Configuration validation failed:\n" + "\n".join(f"  - {err}" for err in errors)
+        error_msg = "Configuration validation failed:\n" + "\n".join(
+            f"  - {err}" for err in errors
+        )
         if logger:
             logger.error(error_msg)
         raise ConfigurationError(error_msg)

--- a/servers/dashboard_server.py
+++ b/servers/dashboard_server.py
@@ -7,6 +7,7 @@ Provides a web interface for monitoring MCP servers, Redis cache, goals, and log
 import asyncio
 import json
 import os
+import logging
 import sys
 import time
 from contextlib import asynccontextmanager
@@ -951,8 +952,8 @@ async def list_goals():
             "source": "PostgreSQL",
         }
     except Exception as e:
-        return {"error": str(e), "goals": [], "count": 0}
-
+        logging.error("Exception in list_goals: %s", e, exc_info=True)
+        return {"error": "An internal server error occurred", "goals": [], "count": 0}
 
 @app.get("/api/goals/{goal_id}")
 async def get_goal_details(goal_id: str):

--- a/servers/dashboard_server.py
+++ b/servers/dashboard_server.py
@@ -240,7 +240,9 @@ def find_server_processes() -> List[Dict[str, Any]]:
                         if "_server.py" in arg:
                             server_name = Path(arg).stem
                             if server_name in server_names:
-                                server_key = server_name.replace("_server", "").replace("_", "-")
+                                server_key = server_name.replace("_server", "").replace(
+                                    "_", "-"
+                                )
 
                                 # Get memory info
                                 memory_mb = (
@@ -254,7 +256,8 @@ def find_server_processes() -> List[Dict[str, Any]]:
                                         "key": server_key,
                                         "name": SERVERS[server_key]["name"],
                                         "pid": proc.info["pid"],
-                                        "uptime": time.time() - proc.info["create_time"],
+                                        "uptime": time.time()
+                                        - proc.info["create_time"],
                                         "memory_mb": round(memory_mb, 2),
                                         "cpu_percent": proc.info.get("cpu_percent", 0),
                                     }
@@ -309,7 +312,9 @@ async def read_root():
     index_file = STATIC_DIR / "index.html"
     if index_file.exists():
         return FileResponse(index_file)
-    return HTMLResponse("<h1>Dashboard not found. Run setup first.</h1>", status_code=404)
+    return HTMLResponse(
+        "<h1>Dashboard not found. Run setup first.</h1>", status_code=404
+    )
 
 
 @app.get("/api/status")
@@ -377,7 +382,9 @@ async def get_servers():
 
         # Check environment variables
         env_configured = (
-            all(os.getenv(var) for var in server["env_vars"]) if server["env_vars"] else True
+            all(os.getenv(var) for var in server["env_vars"])
+            if server["env_vars"]
+            else True
         )
 
         servers_status.append(
@@ -420,7 +427,9 @@ async def get_redis_stats():
             },
             "memory": {
                 "used_memory_mb": round(info.get("used_memory", 0) / (1024 * 1024), 2),
-                "used_memory_peak_mb": round(info.get("used_memory_peak", 0) / (1024 * 1024), 2),
+                "used_memory_peak_mb": round(
+                    info.get("used_memory_peak", 0) / (1024 * 1024), 2
+                ),
                 "memory_fragmentation_ratio": info.get("mem_fragmentation_ratio", 0),
             },
             "clients": {
@@ -438,7 +447,9 @@ async def get_redis_stats():
             "total_keys": redis_client.dbsize(),
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get Redis stats: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to get Redis stats: {str(e)}"
+        )
 
 
 @app.get("/api/goals")
@@ -509,7 +520,9 @@ async def get_goals():
 
         # Get active tasks
         active_tasks = [
-            task for task in tasks_data.values() if task.get("status") in ["in_progress", "pending"]
+            task
+            for task in tasks_data.values()
+            if task.get("status") in ["in_progress", "pending"]
         ][:10]
 
         return {
@@ -967,9 +980,15 @@ async def get_goal_details(goal_id: str):
             "task_count": len(goal_tasks),
             "tasks_by_status": {
                 "pending": sum(1 for t in goal_tasks if t.get("status") == "pending"),
-                "in_progress": sum(1 for t in goal_tasks if t.get("status") == "in_progress"),
-                "completed": sum(1 for t in goal_tasks if t.get("status") == "completed"),
-                "cancelled": sum(1 for t in goal_tasks if t.get("status") == "cancelled"),
+                "in_progress": sum(
+                    1 for t in goal_tasks if t.get("status") == "in_progress"
+                ),
+                "completed": sum(
+                    1 for t in goal_tasks if t.get("status") == "completed"
+                ),
+                "cancelled": sum(
+                    1 for t in goal_tasks if t.get("status") == "cancelled"
+                ),
             },
             "source": "PostgreSQL",
         }
@@ -1000,7 +1019,9 @@ async def delete_goal(goal_id: str):
         success = db.delete_goal(goal_id)
 
         if not success:
-            raise HTTPException(status_code=500, detail=f"Failed to delete goal {goal_id}")
+            raise HTTPException(
+                status_code=500, detail=f"Failed to delete goal {goal_id}"
+            )
 
         return {
             "success": True,
@@ -1033,7 +1054,9 @@ async def delete_task(task_id: str):
         success = db.delete_task(task_id)
 
         if not success:
-            raise HTTPException(status_code=500, detail=f"Failed to delete task {task_id}")
+            raise HTTPException(
+                status_code=500, detail=f"Failed to delete task {task_id}"
+            )
 
         return {
             "success": True,
@@ -1143,7 +1166,9 @@ async def update_task_status(task_id: str, status_data: UpdateTaskStatusRequest)
         # Update task
         from servers.goal_agent_server import agent
 
-        updated_task = agent.update_task_status(task_id, status_data.status, status_data.result)
+        updated_task = agent.update_task_status(
+            task_id, status_data.status, status_data.result
+        )
 
         return {
             "success": True,
@@ -1232,7 +1257,9 @@ async def collect_dashboard_data(include_system_stats: bool = True) -> dict:
                         {
                             "version": info.get("redis_version", "unknown"),
                             "uptime_days": info.get("uptime_in_days", 0),
-                            "used_memory_mb": round(info.get("used_memory", 0) / (1024 * 1024), 2),
+                            "used_memory_mb": round(
+                                info.get("used_memory", 0) / (1024 * 1024), 2
+                            ),
                             "connected_clients": info.get("connected_clients", 0),
                             "ops_per_sec": info.get("instantaneous_ops_per_sec", 0),
                         }
@@ -1281,7 +1308,9 @@ async def collect_dashboard_data(include_system_stats: bool = True) -> dict:
 
             # Check environment variables
             env_configured = (
-                all(os.getenv(var) for var in server["env_vars"]) if server["env_vars"] else True
+                all(os.getenv(var) for var in server["env_vars"])
+                if server["env_vars"]
+                else True
             )
 
             servers_status.append(
@@ -1397,7 +1426,9 @@ async def broadcast_updates():
             update_system_stats = cycle_count % 10 == 0  # Every 1000ms (10 cycles)
 
             # Collect current data (with optional system stats)
-            current_data = await collect_dashboard_data(include_system_stats=update_system_stats)
+            current_data = await collect_dashboard_data(
+                include_system_stats=update_system_stats
+            )
 
             # Smart comparison: only broadcast if meaningful changes occurred
             has_changes = False
@@ -1415,9 +1446,9 @@ async def broadcast_updates():
                 # Check Redis connection or key count
                 curr_redis = current_data.get("status", {}).get("redis", {})
                 prev_redis = previous_data.get("status", {}).get("redis", {})
-                if curr_redis.get("connected") != prev_redis.get("connected") or curr_redis.get(
-                    "total_keys"
-                ) != prev_redis.get("total_keys"):
+                if curr_redis.get("connected") != prev_redis.get(
+                    "connected"
+                ) or curr_redis.get("total_keys") != prev_redis.get("total_keys"):
                     has_changes = True
 
                 # Check system stats (only if included, with rounding to prevent minor fluctuations)

--- a/servers/database.py
+++ b/servers/database.py
@@ -40,7 +40,9 @@ class GoalModel(Base):
     status = Column(String(20), nullable=False, index=True)
     repos = Column(JSON, default=list)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
     meta_data = Column("metadata", JSON, default=dict)
 
     # Relationship to tasks
@@ -94,7 +96,9 @@ class TaskModel(Base):
     estimated_effort = Column(String(50), nullable=True)
     assigned_tools = Column(JSON, default=list)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
     completed_at = Column(DateTime, nullable=True)
     result = Column(JSON, nullable=True)
 
@@ -124,7 +128,9 @@ class TaskModel(Base):
             "assigned_tools": self.assigned_tools or [],
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
-            "completed_at": (self.completed_at.isoformat() if self.completed_at else None),
+            "completed_at": (
+                self.completed_at.isoformat() if self.completed_at else None
+            ),
             "result": self.result,
         }
 
@@ -132,7 +138,9 @@ class TaskModel(Base):
 class DatabaseManager:
     """Manages PostgreSQL database connections and operations."""
 
-    def __init__(self, database_url: str, pool_size: int = 10, max_overflow: int = 20) -> None:
+    def __init__(
+        self, database_url: str, pool_size: int = 10, max_overflow: int = 20
+    ) -> None:
         """
         Initialize database manager.
 

--- a/servers/error_handler.py
+++ b/servers/error_handler.py
@@ -41,7 +41,9 @@ class MCPErrorHandler:
 
         # Check if file exists
         if not Path(file_path).exists():
-            suggestions.append(f"File '{file_path}' does not exist. Check the file path.")
+            suggestions.append(
+                f"File '{file_path}' does not exist. Check the file path."
+            )
             return {
                 "error": f"File not found: {file_path}",
                 "type": "file_not_found",
@@ -69,7 +71,9 @@ class MCPErrorHandler:
 
             # Check for common issues
             if len(old_string.strip()) == 0:
-                suggestions.append("The old_string is empty. Provide the exact text to replace.")
+                suggestions.append(
+                    "The old_string is empty. Provide the exact text to replace."
+                )
             elif len(old_string) > 200:
                 suggestions.append(
                     "The old_string is very long. Try using a shorter, unique portion."
@@ -101,7 +105,9 @@ class MCPErrorHandler:
             ),
         }
 
-    def _find_similar_strings(self, content: str, target: str, threshold: float = 0.7) -> List[str]:
+    def _find_similar_strings(
+        self, content: str, target: str, threshold: float = 0.7
+    ) -> List[str]:
         """Find strings similar to the target in the content."""
         if not target.strip():
             return []
@@ -162,7 +168,9 @@ class MCPErrorHandler:
                     f"Convert string to list: json.loads('{field_value}') or ['{field_value}']"
                 )
             elif expected_type == "dict" and isinstance(field_value, str):
-                suggestions.append(f"Convert string to dict: json.loads('{field_value}')")
+                suggestions.append(
+                    f"Convert string to dict: json.loads('{field_value}')"
+                )
 
         # Common validation issues
         if field_value is None:
@@ -180,7 +188,9 @@ class MCPErrorHandler:
             "field_type": type(field_value).__name__,
             "expected_type": expected_type,
             "suggestion": (
-                "; ".join(suggestions) if suggestions else "Check the field value and format"
+                "; ".join(suggestions)
+                if suggestions
+                else "Check the field value and format"
             ),
         }
 
@@ -228,7 +238,9 @@ class MCPErrorHandler:
             if not path.exists():
                 suggestions.append(f"File '{file_path}' does not exist")
             elif path.is_dir():
-                suggestions.append(f"'{file_path}' is a directory. Use rmdir or remove files first")
+                suggestions.append(
+                    f"'{file_path}' is a directory. Use rmdir or remove files first"
+                )
 
         return {
             "error": f"File {operation} error: {error_msg}",

--- a/servers/file_server.py
+++ b/servers/file_server.py
@@ -79,7 +79,9 @@ class FileSystemClient:
             "/usr/sbin",  # System binaries
         ]
 
-        self.logger.info(f"File server initialized with allowed paths: {self.allowed_paths}")
+        self.logger.info(
+            f"File server initialized with allowed paths: {self.allowed_paths}"
+        )
         self.logger.info(f"Restricted paths: {self.restricted_paths}")
 
     def _validate_path(self, file_path: str, allow_write: bool = False) -> Path:
@@ -115,7 +117,8 @@ class FileSystemClient:
             # Security check: ensure path is within allowed directories
             if self.allowed_paths:
                 is_allowed = any(
-                    path_str.startswith(allowed_path) for allowed_path in self.allowed_paths
+                    path_str.startswith(allowed_path)
+                    for allowed_path in self.allowed_paths
                 )
                 if not is_allowed:
                     raise ValueError(
@@ -168,15 +171,13 @@ class FileSystemClient:
                             for f in path.parent.iterdir()
                             if f.is_file() and path.name.lower() in f.name.lower()
                         ]
-                        suggestion = f"File not found: '{file_path}' (resolved to '{path}'). "
+                        suggestion = (
+                            f"File not found: '{file_path}' (resolved to '{path}'). "
+                        )
                         if similar_files:
-                            suggestion += (
-                                f"Similar files in the same directory: {similar_files[:5]}"
-                            )
+                            suggestion += f"Similar files in the same directory: {similar_files[:5]}"
                         else:
-                            suggestion += (
-                                f"Directory '{path.parent}' exists but contains no similar files."
-                            )
+                            suggestion += f"Directory '{path.parent}' exists but contains no similar files."
                     except (OSError, PermissionError):
                         suggestion = f"File not found: '{file_path}' (resolved to '{path}'). Please check the path."
                 else:
@@ -330,7 +331,9 @@ class FileSystemClient:
                             "path": str(item),
                             "type": "directory" if item.is_dir() else "file",
                             "size": stat.st_size if item.is_file() else None,
-                            "modified": datetime.fromtimestamp(stat.st_mtime).isoformat(),
+                            "modified": datetime.fromtimestamp(
+                                stat.st_mtime
+                            ).isoformat(),
                             "permissions": oct(stat.st_mode)[-3:],
                         }
                     )
@@ -452,8 +455,12 @@ class FileSystemClient:
                                     {
                                         "name": item.name,
                                         "path": str(item),
-                                        "type": ("directory" if item.is_dir() else "file"),
-                                        "size": (stat.st_size if item.is_file() else None),
+                                        "type": (
+                                            "directory" if item.is_dir() else "file"
+                                        ),
+                                        "size": (
+                                            stat.st_size if item.is_file() else None
+                                        ),
                                         "modified": datetime.fromtimestamp(
                                             stat.st_mtime
                                         ).isoformat(),
@@ -548,8 +555,16 @@ class FileSystemClient:
                                             {
                                                 "name": item.name,
                                                 "path": str(item),
-                                                "type": ("directory" if item.is_dir() else "file"),
-                                                "size": (stat.st_size if item.is_file() else None),
+                                                "type": (
+                                                    "directory"
+                                                    if item.is_dir()
+                                                    else "file"
+                                                ),
+                                                "size": (
+                                                    stat.st_size
+                                                    if item.is_file()
+                                                    else None
+                                                ),
                                                 "modified": datetime.fromtimestamp(
                                                     stat.st_mtime
                                                 ).isoformat(),
@@ -624,11 +639,15 @@ def read_file(file_path: str, encoding: str = "utf-8") -> str:
 
     except FileNotFoundError as e:
         logger.error(f"File not found in read_file: {e}")
-        error_response = error_handler.handle_file_operation_error(str(e), "read", file_path)
+        error_response = error_handler.handle_file_operation_error(
+            str(e), "read", file_path
+        )
         return safe_json_dumps(error_response)
     except ValueError as e:
         logger.error(f"Validation error in read_file: {e}")
-        error_response = error_handler.handle_validation_error(str(e), "file_path", file_path)
+        error_response = error_handler.handle_validation_error(
+            str(e), "file_path", file_path
+        )
         return safe_json_dumps(error_response)
     except Exception as e:
         logger.error(f"Unexpected error in read_file: {e}")
@@ -692,7 +711,9 @@ def write_file(
 
 
 @mcp.tool()
-def list_directory(dir_path: str, include_hidden: bool = False, recursive: bool = False) -> str:
+def list_directory(
+    dir_path: str, include_hidden: bool = False, recursive: bool = False
+) -> str:
     """
     List the contents of a directory.
 
@@ -762,7 +783,9 @@ def search_files(
 
 
 @mcp.tool()
-def search_files_system_wide(pattern: str, include_hidden: bool = False, max_depth: int = 3) -> str:
+def search_files_system_wide(
+    pattern: str, include_hidden: bool = False, max_depth: int = 3
+) -> str:
     """
     Search for files system-wide within allowed directories.
 
@@ -776,7 +799,9 @@ def search_files_system_wide(pattern: str, include_hidden: bool = False, max_dep
     """
     try:
         validate_non_empty(pattern, "pattern")
-        result = file_client.search_files_system_wide(pattern, include_hidden, max_depth)
+        result = file_client.search_files_system_wide(
+            pattern, include_hidden, max_depth
+        )
         return json.dumps(result, indent=2)
     except Exception as e:
         logger.error(f"Error in search_files_system_wide: {e}")

--- a/servers/frappe_server.py
+++ b/servers/frappe_server.py
@@ -151,7 +151,9 @@ class FrappeClient(BaseClient):
 
         return result
 
-    def update_document(self, doctype: str, name: str, data: dict[str, Any]) -> dict[str, Any]:
+    def update_document(
+        self, doctype: str, name: str, data: dict[str, Any]
+    ) -> dict[str, Any]:
         """
         Update an existing document.
 

--- a/servers/github_server.py
+++ b/servers/github_server.py
@@ -42,7 +42,9 @@ class GitHubClient:
         self.config = config
 
         auth = Auth.Token(config.token)
-        self.client = Github(auth=auth, timeout=config.timeout, retry=config.max_retries)
+        self.client = Github(
+            auth=auth, timeout=config.timeout, retry=config.max_retries
+        )
         self.default_branch = config.default_branch
 
         # Verify authentication
@@ -57,7 +59,9 @@ class GitHubClient:
         self, username: str | None = None, sort: str = "updated", limit: int = 20
     ) -> list[dict]:
         """List repositories for a user or authenticated user."""
-        logger.debug(f"Listing repositories (user: {username or 'authenticated'}, limit: {limit})")
+        logger.debug(
+            f"Listing repositories (user: {username or 'authenticated'}, limit: {limit})"
+        )
 
         try:
             if username:
@@ -84,8 +88,12 @@ class GitHubClient:
                         "forks": repo.forks_count,
                         "open_issues": repo.open_issues_count,
                         "default_branch": repo.default_branch,
-                        "created_at": (repo.created_at.isoformat() if repo.created_at else None),
-                        "updated_at": (repo.updated_at.isoformat() if repo.updated_at else None),
+                        "created_at": (
+                            repo.created_at.isoformat() if repo.created_at else None
+                        ),
+                        "updated_at": (
+                            repo.updated_at.isoformat() if repo.updated_at else None
+                        ),
                     }
                 )
 
@@ -96,7 +104,9 @@ class GitHubClient:
             logger.error(f"Failed to list repositories: {e}")
             raise
 
-    def get_file_content(self, repo_name: str, file_path: str, branch: str = "main") -> dict:
+    def get_file_content(
+        self, repo_name: str, file_path: str, branch: str = "main"
+    ) -> dict:
         """Get content of a specific file from a repository."""
         logger.debug(f"Fetching file: {repo_name}/{file_path} (branch: {branch})")
 
@@ -309,7 +319,9 @@ class GitHubClient:
             logger.error(f"Failed to get branch info: {e}")
             raise
 
-    def create_branch(self, repo_name: str, branch_name: str, source_branch: str = "main") -> dict:
+    def create_branch(
+        self, repo_name: str, branch_name: str, source_branch: str = "main"
+    ) -> dict:
         """
         Create a new branch from a source branch.
 
@@ -321,7 +333,9 @@ class GitHubClient:
         Returns:
             Created branch information
         """
-        logger.debug(f"Creating branch {branch_name} from {source_branch} in {repo_name}")
+        logger.debug(
+            f"Creating branch {branch_name} from {source_branch} in {repo_name}"
+        )
 
         try:
             repo = self.client.get_repo(repo_name)
@@ -347,7 +361,9 @@ class GitHubClient:
             source_sha = source_ref.object.sha
 
             # Create new branch
-            new_ref = repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=source_sha)
+            new_ref = repo.create_git_ref(
+                ref=f"refs/heads/{branch_name}", sha=source_sha
+            )
 
             logger.info(f"Created branch: {branch_name} at {source_sha[:7]}")
 
@@ -508,7 +524,9 @@ class GitHubClient:
             branch_ref = repo.get_git_ref(f"heads/{branch}")
             branch_ref.edit(new_commit.sha)
 
-            logger.info(f"Committed {len(files)} files to {branch}: {new_commit.sha[:7]}")
+            logger.info(
+                f"Committed {len(files)} files to {branch}: {new_commit.sha[:7]}"
+            )
 
             return {
                 "success": True,
@@ -625,7 +643,9 @@ class GitHubClient:
 
                 # Recursively get subdirectories
                 if recursive and item.type == "dir":
-                    subtree = self.get_directory_tree(repo_name, item.path, branch, True)
+                    subtree = self.get_directory_tree(
+                        repo_name, item.path, branch, True
+                    )
                     tree.extend(subtree)
 
             logger.info(f"Retrieved directory tree with {len(tree)} items")
@@ -670,7 +690,9 @@ except Exception as e:
 # MCP Tools
 @mcp.tool()
 @handle_errors(logger)
-def list_repositories(username: str | None = None, sort: str = "updated", limit: int = 20) -> str:
+def list_repositories(
+    username: str | None = None, sort: str = "updated", limit: int = 20
+) -> str:
     """
     List repositories for a user or authenticated user.
 
@@ -763,13 +785,17 @@ def create_issue(
     labels_list = json.loads(labels) if labels else None
     assignees_list = json.loads(assignees) if assignees else None
 
-    issue = github_client.create_issue(repo_name, title, body, labels_list, assignees_list)
+    issue = github_client.create_issue(
+        repo_name, title, body, labels_list, assignees_list
+    )
     return json.dumps(issue, indent=2)
 
 
 @mcp.tool()
 @handle_errors(logger)
-def create_pull_request(repo_name: str, title: str, head: str, base: str, body: str = "") -> str:
+def create_pull_request(
+    repo_name: str, title: str, head: str, base: str, body: str = ""
+) -> str:
     """
     Create a pull request.
 
@@ -963,7 +989,9 @@ def delete_file(
     if not github_client:
         return json.dumps({"error": "GitHub client not initialized"})
 
-    result = github_client.delete_file(repo_name, file_path, commit_message, branch, sha)
+    result = github_client.delete_file(
+        repo_name, file_path, commit_message, branch, sha
+    )
     return json.dumps(result, indent=2)
 
 

--- a/servers/goal_agent_server.py
+++ b/servers/goal_agent_server.py
@@ -344,7 +344,9 @@ class GoalAgent:
         return goal
 
     @with_lock
-    def break_down_goal(self, goal_id: str, subtasks: list[dict[str, Any]]) -> dict[str, Any]:
+    def break_down_goal(
+        self, goal_id: str, subtasks: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         """Break down a goal into executable subtasks and persist to database."""
         goal = self.db.get_goal(goal_id)
         if not goal:
@@ -530,7 +532,8 @@ class GoalAgent:
 
                 # Check if all dependencies are completed
                 dependencies_met = all(
-                    (dep_task := self.db.get_task(dep_id)) and dep_task.status == "completed"
+                    (dep_task := self.db.get_task(dep_id))
+                    and dep_task.status == "completed"
                     for dep_id in task.dependencies
                 )
 
@@ -612,7 +615,8 @@ class GoalAgent:
 
                 for task in remaining_tasks[:]:
                     dependencies_met = all(
-                        dep_id in completed_task_ids or dep_id not in [t.id for t in tasks]
+                        dep_id in completed_task_ids
+                        or dep_id not in [t.id for t in tasks]
                         for dep_id in task.dependencies
                     )
 
@@ -669,17 +673,23 @@ class GoalAgent:
             result = update.get("result")
 
             if not task_id or not status:
-                results["failed"].append({"task_id": task_id, "error": "Missing task_id or status"})
+                results["failed"].append(
+                    {"task_id": task_id, "error": "Missing task_id or status"}
+                )
                 continue
 
-            future = self.executor.submit(self.update_task_status, task_id, status, result)
+            future = self.executor.submit(
+                self.update_task_status, task_id, status, result
+            )
             futures[future] = task_id
 
         for future in as_completed(futures):
             task_id = futures[future]
             try:
                 updated_task = future.result()
-                results["successful"].append({"task_id": task_id, "status": updated_task["status"]})
+                results["successful"].append(
+                    {"task_id": task_id, "status": updated_task["status"]}
+                )
             except Exception as e:
                 results["failed"].append({"task_id": task_id, "error": str(e)})
                 logger.error(f"Failed to update {task_id}: {e}")
@@ -1042,7 +1052,9 @@ def update_goal(
     repos_list = json.loads(repos) if repos else None
     metadata_dict = json.loads(metadata) if metadata else None
 
-    result = agent.update_goal(goal_id, description, priority, status, repos_list, metadata_dict)
+    result = agent.update_goal(
+        goal_id, description, priority, status, repos_list, metadata_dict
+    )
 
     result["_persistence"] = {
         "database": "PostgreSQL",

--- a/servers/internet_server.py
+++ b/servers/internet_server.py
@@ -54,7 +54,9 @@ class InternetClient(BaseClient):
         self.config = config
         self.search_endpoint = "/customsearch/v1"
         self.max_workers = max_workers
-        self.executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="Internet")
+        self.executor = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="Internet"
+        )
 
         import atexit
 
@@ -62,7 +64,9 @@ class InternetClient(BaseClient):
 
         logger.info(f"Internet client initialized with {max_workers} worker threads")
 
-    def _generate_cache_key(self, url_or_query: str, params: dict[str, Any] | None = None) -> str:
+    def _generate_cache_key(
+        self, url_or_query: str, params: dict[str, Any] | None = None
+    ) -> str:
         """Generate cache key for requests."""
         key_data = url_or_query
         if params:
@@ -171,7 +175,9 @@ class InternetClient(BaseClient):
             logger.error(f"Failed to fetch {url}: {e}")
             raise
 
-    def batch_fetch_urls(self, urls: list[str], timeout: int | None = None) -> dict[str, Any]:
+    def batch_fetch_urls(
+        self, urls: list[str], timeout: int | None = None
+    ) -> dict[str, Any]:
         """Fetch multiple URLs concurrently using ThreadPoolExecutor."""
         logger.info(f"Starting batch fetch for {len(urls)} URLs")
 
@@ -342,7 +348,9 @@ def web_search(
     """Search the web using Google Custom Search API."""
     if not internet_client:
         return json.dumps({"error": "Internet client not initialized"})
-    results = internet_client.search(query, max_results, search_type, file_type, date_restrict)
+    results = internet_client.search(
+        query, max_results, search_type, file_type, date_restrict
+    )
     return json.dumps(results, indent=2)
 
 
@@ -380,7 +388,9 @@ def batch_search(queries: str, max_results: int = 10) -> str:
 
 @mcp.tool()
 @handle_errors(logger)
-def search_and_fetch(query: str, max_results: int = 5, fetch_content: bool = True) -> str:
+def search_and_fetch(
+    query: str, max_results: int = 5, fetch_content: bool = True
+) -> str:
     """Search and fetch full content from top results in one operation."""
     if not internet_client:
         return json.dumps({"error": "Internet client not initialized"})

--- a/servers/jira_server.py
+++ b/servers/jira_server.py
@@ -82,7 +82,9 @@ class JiraClient(BaseClient):
     def _verify_agile_api(self) -> bool:
         """Check if Agile API is available."""
         try:
-            self._make_jira_request("GET", "/rest/agile/1.0/board", params={"maxResults": 1})
+            self._make_jira_request(
+                "GET", "/rest/agile/1.0/board", params={"maxResults": 1}
+            )
             logger.info("Agile API is available")
             return True
         except Exception as e:
@@ -118,7 +120,9 @@ class JiraClient(BaseClient):
                 return " | ".join(error_data["errorMessages"])
 
             if "errors" in error_data and error_data["errors"]:
-                errors = [f"{field}: {msg}" for field, msg in error_data["errors"].items()]
+                errors = [
+                    f"{field}: {msg}" for field, msg in error_data["errors"].items()
+                ]
                 return " | ".join(errors)
 
             return error_data.get("message", response.text[:500])
@@ -236,7 +240,9 @@ class JiraClient(BaseClient):
         if fields:
             params["fields"] = ",".join(fields)
 
-        response = self._make_jira_request("GET", f"/rest/api/3/issue/{issue_key}", params=params)
+        response = self._make_jira_request(
+            "GET", f"/rest/api/3/issue/{issue_key}", params=params
+        )
         data = response.json()
 
         logger.info(f"Retrieved issue: {issue_key}")
@@ -420,7 +426,9 @@ class JiraClient(BaseClient):
         logger.debug(f"Issue creation payload: {json.dumps(payload, indent=2)}")
 
         try:
-            response = self._make_jira_request("POST", "/rest/api/3/issue", json=payload)
+            response = self._make_jira_request(
+                "POST", "/rest/api/3/issue", json=payload
+            )
             data = response.json()
 
             logger.debug(f"Create response: {json.dumps(data, indent=2)}")
@@ -446,7 +454,9 @@ class JiraClient(BaseClient):
             }
 
         except Exception as e:
-            logger.error(f"Failed to create issue. Payload: {json.dumps(payload, indent=2)}")
+            logger.error(
+                f"Failed to create issue. Payload: {json.dumps(payload, indent=2)}"
+            )
             logger.error(f"Error: {str(e)}")
             raise
 
@@ -490,7 +500,9 @@ class JiraClient(BaseClient):
         payload = {"issueUpdates": issue_updates}
 
         try:
-            response = self._make_jira_request("POST", "/rest/api/3/issue/bulk", json=payload)
+            response = self._make_jira_request(
+                "POST", "/rest/api/3/issue/bulk", json=payload
+            )
             data = response.json()
 
             successful = len(data.get("issues", []))
@@ -524,7 +536,9 @@ class JiraClient(BaseClient):
         payload = {"fields": fields}
 
         try:
-            self._make_jira_request("PUT", f"/rest/api/3/issue/{issue_key}", json=payload)
+            self._make_jira_request(
+                "PUT", f"/rest/api/3/issue/{issue_key}", json=payload
+            )
             logger.info(f"Updated issue: {issue_key}")
             return True
 
@@ -573,14 +587,18 @@ class JiraClient(BaseClient):
         payload = {"transition": {"id": transition_id}}
 
         if comment:
-            payload["update"] = {"comment": [{"add": {"body": self._format_description(comment)}}]}
+            payload["update"] = {
+                "comment": [{"add": {"body": self._format_description(comment)}}]
+            }
 
         if fields:
             payload["fields"] = fields
 
         logger.debug(f"Transition payload: {json.dumps(payload, indent=2)}")
 
-        self._make_jira_request("POST", f"/rest/api/3/issue/{issue_key}/transitions", json=payload)
+        self._make_jira_request(
+            "POST", f"/rest/api/3/issue/{issue_key}/transitions", json=payload
+        )
 
         logger.info(f"Transitioned issue: {issue_key}")
         return True
@@ -597,7 +615,9 @@ class JiraClient(BaseClient):
         """
         logger.debug(f"Fetching transitions for: {issue_key}")
 
-        response = self._make_jira_request("GET", f"/rest/api/3/issue/{issue_key}/transitions")
+        response = self._make_jira_request(
+            "GET", f"/rest/api/3/issue/{issue_key}/transitions"
+        )
         data = response.json()
 
         transitions = data.get("transitions", [])
@@ -605,7 +625,9 @@ class JiraClient(BaseClient):
 
         return transitions
 
-    def add_comment(self, issue_key: str, comment: str, rich_text: bool = False) -> Dict:
+    def add_comment(
+        self, issue_key: str, comment: str, rich_text: bool = False
+    ) -> Dict:
         """
         Add a comment to an issue.
 
@@ -641,7 +663,9 @@ class JiraClient(BaseClient):
         """
         logger.debug(f"Fetching comments for: {issue_key}")
 
-        response = self._make_jira_request("GET", f"/rest/api/3/issue/{issue_key}/comment")
+        response = self._make_jira_request(
+            "GET", f"/rest/api/3/issue/{issue_key}/comment"
+        )
         data = response.json()
 
         comments = data.get("comments", [])
@@ -706,7 +730,9 @@ class JiraClient(BaseClient):
 
         payload = {"accountId": account_id}
 
-        self._make_jira_request("PUT", f"/rest/api/3/issue/{issue_key}/assignee", json=payload)
+        self._make_jira_request(
+            "PUT", f"/rest/api/3/issue/{issue_key}/assignee", json=payload
+        )
 
         logger.info(f"Assigned issue {issue_key}")
         return True
@@ -723,7 +749,9 @@ class JiraClient(BaseClient):
         """
         logger.debug(f"Fetching watchers for: {issue_key}")
 
-        response = self._make_jira_request("GET", f"/rest/api/3/issue/{issue_key}/watchers")
+        response = self._make_jira_request(
+            "GET", f"/rest/api/3/issue/{issue_key}/watchers"
+        )
         data = response.json()
 
         logger.info(f"Retrieved watchers for {issue_key}")
@@ -742,14 +770,18 @@ class JiraClient(BaseClient):
         """
         logger.debug(f"Adding watcher to {issue_key}")
 
-        self._make_jira_request("POST", f"/rest/api/3/issue/{issue_key}/watchers", json=account_id)
+        self._make_jira_request(
+            "POST", f"/rest/api/3/issue/{issue_key}/watchers", json=account_id
+        )
 
         logger.info(f"Added watcher to {issue_key}")
         return True
 
     # Sprint and Board Management Methods
 
-    def get_boards(self, project_key: Optional[str] = None, max_results: int = 50) -> List[Dict]:
+    def get_boards(
+        self, project_key: Optional[str] = None, max_results: int = 50
+    ) -> List[Dict]:
         """
         Get boards, optionally filtered by project.
 
@@ -769,7 +801,9 @@ class JiraClient(BaseClient):
         if project_key:
             params["projectKeyOrId"] = project_key
 
-        response = self._make_jira_request("GET", "/rest/agile/1.0/board", params=params)
+        response = self._make_jira_request(
+            "GET", "/rest/agile/1.0/board", params=params
+        )
         data = response.json()
 
         boards = data.get("values", [])
@@ -861,7 +895,9 @@ class JiraClient(BaseClient):
 
         payload = {"issues": issue_keys}
 
-        self._make_jira_request("POST", f"/rest/agile/1.0/sprint/{sprint_id}/issue", json=payload)
+        self._make_jira_request(
+            "POST", f"/rest/agile/1.0/sprint/{sprint_id}/issue", json=payload
+        )
 
         logger.info(f"Added issues to sprint {sprint_id}")
         return True
@@ -1069,7 +1105,9 @@ def jira_get_create_metadata(project_key: str, issue_type_id: str) -> str:
 
 @mcp.tool()
 @handle_errors(logger)
-def jira_check_story_points_requirement(project_key: str, issue_type: str = "Story") -> str:
+def jira_check_story_points_requirement(
+    project_key: str, issue_type: str = "Story"
+) -> str:
     """
     Check if story points are required for a specific issue type in a project.
 
@@ -1142,7 +1180,9 @@ def jira_check_story_points_requirement(project_key: str, issue_type: str = "Sto
                                             "field_id": field_id,
                                             "field_name": field_data.get("name"),
                                             "required": is_required,
-                                            "field_type": field_data.get("schema", {}).get("type"),
+                                            "field_type": field_data.get(
+                                                "schema", {}
+                                            ).get("type"),
                                         }
                                     )
 
@@ -1151,7 +1191,9 @@ def jira_check_story_points_requirement(project_key: str, issue_type: str = "Sto
                                         {
                                             "field_id": field_id,
                                             "field_name": field_data.get("name"),
-                                            "field_type": field_data.get("schema", {}).get("type"),
+                                            "field_type": field_data.get(
+                                                "schema", {}
+                                            ).get("type"),
                                         }
                                     )
 
@@ -1159,7 +1201,9 @@ def jira_check_story_points_requirement(project_key: str, issue_type: str = "Sto
             {
                 "project_key": project_key,
                 "issue_type": issue_type,
-                "story_points_required": any(field["required"] for field in story_points_fields),
+                "story_points_required": any(
+                    field["required"] for field in story_points_fields
+                ),
                 "story_points_fields": story_points_fields,
                 "all_required_fields": required_fields,
                 "suggestion": "Use the story_points parameter when creating issues if story points are required.",
@@ -1310,7 +1354,10 @@ def jira_create_issue(
 
         # Check for common Jira errors and provide helpful suggestions
         if "required field" in error_msg.lower():
-            if "story points" in error_msg.lower() or "customfield" in error_msg.lower():
+            if (
+                "story points" in error_msg.lower()
+                or "customfield" in error_msg.lower()
+            ):
                 return json.dumps(
                     {
                         "error": f"Story points are required for this issue type: {error_msg}",
@@ -1379,7 +1426,11 @@ def jira_create_issues_bulk(issues: str) -> str:
 
             # Validate story points value
             story_points = issue["story_points"]
-            if not isinstance(story_points, int) or story_points < 1 or story_points > 100:
+            if (
+                not isinstance(story_points, int)
+                or story_points < 1
+                or story_points > 100
+            ):
                 return json.dumps(
                     {
                         "error": f"Issue {i+1} has invalid story_points value: {story_points}. Must be an integer between 1 and 100.",
@@ -1465,7 +1516,9 @@ def jira_transition_issue(
         return json.dumps({"error": "Jira client not initialized"})
 
     fields_dict = json.loads(fields) if fields else None
-    result = jira_client.transition_issue(issue_key, transition_id, comment, fields_dict)
+    result = jira_client.transition_issue(
+        issue_key, transition_id, comment, fields_dict
+    )
     return json.dumps({"success": result})
 
 
@@ -1530,7 +1583,9 @@ def jira_get_comments(issue_key: str) -> str:
 
 @mcp.tool()
 @handle_errors(logger)
-def jira_link_issues(inward_issue: str, outward_issue: str, link_type: str = "Relates") -> str:
+def jira_link_issues(
+    inward_issue: str, outward_issue: str, link_type: str = "Relates"
+) -> str:
     """
     Create a link between two Jira issues.
 

--- a/servers/logging_config.py
+++ b/servers/logging_config.py
@@ -21,10 +21,18 @@ class CustomFormatter(logging.Formatter):
     reset = "\x1b[0m"
 
     FORMATS = {
-        logging.DEBUG: grey + "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s" + reset,
-        logging.INFO: blue + "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s" + reset,
-        logging.WARNING: yellow + "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s" + reset,
-        logging.ERROR: red + "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s" + reset,
+        logging.DEBUG: grey
+        + "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s"
+        + reset,
+        logging.INFO: blue
+        + "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s"
+        + reset,
+        logging.WARNING: yellow
+        + "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s"
+        + reset,
+        logging.ERROR: red
+        + "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s"
+        + reset,
         logging.CRITICAL: bold_red
         + "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s"
         + reset,
@@ -102,7 +110,9 @@ def setup_logging(
     return logger
 
 
-def log_server_startup(logger: logging.Logger, server_name: str, config: dict[str, Any]) -> None:
+def log_server_startup(
+    logger: logging.Logger, server_name: str, config: dict[str, Any]
+) -> None:
     """Log server startup information."""
     logger.info("=" * 70)
     logger.info(f"{server_name} Starting")
@@ -112,7 +122,10 @@ def log_server_startup(logger: logging.Logger, server_name: str, config: dict[st
 
     for key, value in config.items():
         # Mask sensitive information
-        if any(secret in key.lower() for secret in ["token", "secret", "password", "key", "api"]):
+        if any(
+            secret in key.lower()
+            for secret in ["token", "secret", "password", "key", "api"]
+        ):
             logger.info(f"{key}: {'*' * 8}")
         else:
             logger.info(f"{key}: {value}")

--- a/servers/memory_cache_server.py
+++ b/servers/memory_cache_server.py
@@ -75,7 +75,9 @@ class RedisCacheClient:
         try:
             if self._client:
                 self._client.ping()
-                logger.info(f"Connected to Redis at {self.config.host}:{self.config.port}")
+                logger.info(
+                    f"Connected to Redis at {self.config.host}:{self.config.port}"
+                )
         except RedisConnectionError as e:
             logger.error(f"Failed to connect to Redis: {e}")
             raise
@@ -279,7 +281,9 @@ class RedisCacheClient:
             logger.error(f"Failed to search keys: {e}")
             raise
 
-    def scan(self, cursor: int = 0, match: str | None = None, count: int = 10) -> dict[str, Any]:
+    def scan(
+        self, cursor: int = 0, match: str | None = None, count: int = 10
+    ) -> dict[str, Any]:
         """
         Incrementally iterate over keys (production-safe).
 


### PR DESCRIPTION
Potential fix for [https://github.com/souravs72/claude-mcp-setup/security/code-scanning/7](https://github.com/souravs72/claude-mcp-setup/security/code-scanning/7)

**General approach:**  
Do not return the raw exception string to the client. Instead, log the exception (with traceback if possible) on the server for debugging. To the client, return a generic error message such as "An internal error has occurred" or similar, and do not leak any internal details.

**Specific fix:**  
- In `servers/dashboard_server.py`, in the `except Exception as e:` block for the `list_goals` endpoint (lines 953-955), remove the direct exposure of `str(e)` to the user.  
- Instead, internally log the full exception (for developer reference) using Python's `logging` module.
- To the API user, return a generic error string, e.g. `{"error": "An internal server error occurred", ...}`.
- To log, ensure the module imports `logging` and has (at least) basic configuration.

**Required changes:**  
- Add `import logging` at the top (if not present in the lines shown).  
- Set up basic logging if not already done (if you have not been shown config, just use `logging.error(...)`).  
- Update the exception handler in `list_goals` to log the error and return a generic message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
